### PR TITLE
Upgrade esbuild to 0.13.15

### DIFF
--- a/packages/vite-plugin-commonjs/package.json
+++ b/packages/vite-plugin-commonjs/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/originjs/vite-plugins/tree/main/packages/vite-plugin-commonjs",
   "dependencies": {
-    "esbuild": "^0.12.6"
+    "esbuild": "^0.13.15"
   },
   "devDependencies": {
     "@types/node": "^15.12.2",


### PR DESCRIPTION
Just keeping things up to date which helps keep this in sync with `vite` which currently depends on `esbuild "^0.13.2"`.