### PR TITLE
fix: support exports array access notation

### DIFF
--- a/packages/vite-plugin-commonjs/__tests__/transform.spec.ts
+++ b/packages/vite-plugin-commonjs/__tests__/transform.spec.ts
@@ -49,6 +49,10 @@ test('require in comments', () => {
 test('isCommonJS', () => {
     expect(isCommonJS(`module.exports = {}`)).toBeTruthy();
     expect(isCommonJS(`exports = { hello: false }`)).toBeTruthy();
+    expect(isCommonJS(`exports.foo = 1`)).toBeTruthy();
+    expect(isCommonJS(`exports[key] = 1`)).toBeTruthy();
+    expect(isCommonJS(`exports[1] = 1`)).toBeTruthy();
+    expect(isCommonJS(`exports['some key'] = 1`)).toBeTruthy();
 });
 
 test('Both url and comments are present', () => {

--- a/packages/vite-plugin-commonjs/src/lib.ts
+++ b/packages/vite-plugin-commonjs/src/lib.ts
@@ -1,4 +1,4 @@
-const commonJSRegex: RegExp = /\b(module\.exports|exports\.\w+|exports\s*=\s*)/;
+const commonJSRegex: RegExp = /\b(module\.exports|exports\.\w+|exports\s*=\s*|exports\s*\[.*\]\s*=\s*)/;
 const requireRegex: RegExp = /_{0,2}require\s*\(\s*(["'].*?["'])\s*\)/g;
 const IMPORT_STRING_PREFIX: String = "__require_for_vite";
 const multilineCommentsRegex = /\/\*(.|[\r\n])*?\*\//gm


### PR DESCRIPTION
Hey! Thanks for the module.

I added to the CommonJS test regexp the exports array notation: `exports[foo]`.

Specifically, i needed to import Jest snapshots in vite and they are CommonJS files using `exports['some snapshot']` so i needed this plugin, but unfortunately the test regexp was failing. This PR fixes this issue.
