### PR TITLE
Bump vite-plugin-commonjs to 1.0.3

### DIFF
--- a/packages/vite-plugin-commonjs/package.json
+++ b/packages/vite-plugin-commonjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@originjs/vite-plugin-commonjs",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A vite plugin that support commonjs to esm in vite",
   "scripts": {
     "build": "tsc -p tsconfig.json"


### PR DESCRIPTION
Bumping the version of vite-plugin-commonjs to release the upgraded esbuild dependency.﻿
