### PR TITLE
feat: source-map using MagicString

### DIFF
--- a/packages/vite-plugin-commonjs/package.json
+++ b/packages/vite-plugin-commonjs/package.json
@@ -25,7 +25,8 @@
   },
   "homepage": "https://github.com/originjs/vite-plugins/tree/main/packages/vite-plugin-commonjs",
   "dependencies": {
-    "esbuild": "^0.14.14"
+    "esbuild": "^0.14.14",
+    "magic-string": "^0.30.0"
   },
   "devDependencies": {
     "@types/node": "^15.12.2",

--- a/packages/vite-plugin-commonjs/package.json
+++ b/packages/vite-plugin-commonjs/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.3",
   "description": "A vite plugin that support commonjs to esm in vite",
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch"
   },
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
Fixes misalignment of `debugger` statements etc. when using this plugin, which forced us back to Webpack.

---

Barely tested due to:
- Bug introduced in https://github.com/originjs/vite-plugins/pull/26#issuecomment-1604608272 (only tested briefly with other hacks)
- Not using esbuild (entirely untested)

We'll probably migrate to another package which has a proper JS parser (instead of hacky regex), so I'm not sure how much time I'll invest into improving this PR.