### PR TITLE
Update lib.ts to support exports that start with `$` and `_`

### DIFF
--- a/packages/vite-plugin-commonjs/src/lib.ts
+++ b/packages/vite-plugin-commonjs/src/lib.ts
@@ -1,4 +1,4 @@
-const commonJSRegex: RegExp = /\b(module\.exports|exports\.\w+|exports\s*=\s*|exports\s*\[.*\]\s*=\s*)/;
+const commonJSRegex: RegExp = /\b(module\.exports|exports\.[\w|$|_]+|exports\s*=\s*|exports\s*\[.*\]\s*=\s*)/;
 const requireRegex: RegExp = /(?<!\.)\b_{0,2}require\s*\(\s*(["'`].*?["'`])\s*\)/g;
 const IMPORT_STRING_PREFIX: String = "__require_for_vite";
 const multilineCommentsRegex = /\/\*(.|[\r\n])*?\*\//gm


### PR DESCRIPTION
This will detect exports that start with `$` and `_`.

Here is a snippet from `@lexical/html` that was causing an issue for me: 

```js
exports.$generateHtmlFromNodes = $generateHtmlFromNodes;
exports.$generateNodesFromDOM = $generateNodesFromDOM;
```

The updated regex will correctly identify this module as common-js.