### PR TITLE
upgrade esbuild to 0.25.0

### DIFF
--- a/packages/vite-plugin-commonjs/package.json
+++ b/packages/vite-plugin-commonjs/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/originjs/vite-plugins/tree/main/packages/vite-plugin-commonjs",
   "dependencies": {
-    "esbuild": "^0.14.14"
+    "esbuild": "^0.25.0"
   },
   "devDependencies": {
     "@types/node": "^15.12.2",


### PR DESCRIPTION
Vulnerability Issue https://github.com/advisories/GHSA-67mh-4wv8-2f99 requires esbuild 0.25.0