### PR TITLE
modify regex for multilineComments

### DIFF
--- a/packages/vite-plugin-commonjs/src/lib.ts
+++ b/packages/vite-plugin-commonjs/src/lib.ts
@@ -1,7 +1,7 @@
 const commonJSRegex: RegExp = /\b(module\.exports|exports\.\w+|exports\s*=\s*|exports\s*\[.*\]\s*=\s*)/;
 const requireRegex: RegExp = /(?<!\.)\b_{0,2}require\s*\(\s*(["'`].*?["'`])\s*\)/g;
 const IMPORT_STRING_PREFIX: String = "__require_for_vite";
-const multilineCommentsRegex = /\/\*(.|[\r\n])*?\*\//gm
+const multilineCommentsRegex = /\/\*[\s\S]*?\*\//gm
 const singleCommentsRegex = /([^\:])\/\/.*/g
 
 export interface TransformRequireResult {


### PR DESCRIPTION
Fixes this issue: https://github.com/originjs/vite-plugins/issues/58

This new regex is much more efficient while maintaining the same behavior, thus avoiding the error explained in the above issue.